### PR TITLE
feat: Options for install and run

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Additionally, the version of xcodegen can be specified:
   The version of xcodegen to be used. Check <https://github.com/yonaskolb/XcodeGen/releases> for valid options.
   Omit this input or use 'latest' to use the latest version.
 
+Moreover, steps of install or run xcodegen can be specified:
+
+* `intall`:
+  Install xcodegen or not.
+* `run`:
+  Run xcodegen or not.
+
 ## Example usage
 
 ```yaml

--- a/index.js
+++ b/index.js
@@ -84,6 +84,16 @@ async function runXcodegen() {
 }
  
 async function main() {
-  await installXcodegen()
-  await runXcodegen()  
+  const input = {
+    install: core.getInput('install'),
+    run:     core.getInput('run'),
+  }
+
+  if (!input.install || input.install === 'true') {
+    await installXcodegen()
+  }
+
+  if (!input.run || input.run === 'true') {
+    await runXcodegen()
+  }
 }


### PR DESCRIPTION
## Overview

Add flags for install and run xcodegen.

### Install flag use case
The flag can be useful when you want to control run xcodegen with just installed or cached.

### Run flag use case
The flag can be useful when install xcodegen with this action but run xcodegen via task runner.
