### PR TITLE
fix: add install and run inputs on action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,11 @@ inputs:
   version:
     description: 'The version of xcodegen to be used. Check https://github.com/yonaskolb/XcodeGen/releases for valid options.'
     default: latest
+  install:
+    description: 'Whether to install xcodegen or not'
+  run:
+    description: 'Whether to run xcodegen or not'
+
 runs:
   using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
## Overview
Features added in #14 might work correctly, but when setting run or install, the following warning appears:

```
Warning: Unexpected input(s) 'run', valid inputs are ['cache-path', 'no-env', 'only-plists', 'project', 'project-root', 'quiet', 'spec', 'use-cache', 'version']
```

I forgot to add the inputs to action.yml.