### PR TITLE
build: Support Node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ inputs:
     description: 'The version of xcodegen to be used. Check https://github.com/yonaskolb/XcodeGen/releases for valid options.'
     default: latest
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "action-xcodegen",
-  "version": "1.1.2",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "action-xcodegen",
-  "version": "1.1.2",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "action-xcodegen",
-      "version": "1.1.2",
+      "version": "1.2.2",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.1",


### PR DESCRIPTION
From the 15th of October, GitHub Actions will no longer include Node16 in the Actions runner.
https://github.blog/changelog/2024-09-25-end-of-life-for-actions-node16/

I updated `action.yml` and lockfiles wtih `npm i` on Node20.