### PR TITLE
Fix username issue when running on a Cirrus Runner

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ async function installXcodegen() {
   ])
   await exec.exec('unzip', ['-q', '-o', zipFile], { cwd: xcodegenDir })
   await exec.exec('rm', [zipFile])
-  await exec.exec('sudo', ['chown', '-R', `${currentUser}:admin`, installPath])
+  await exec.exec('sudo', ['chown', '-R', `${currentUser}:admin`, '/usr/local/share'])
   await exec.exec('xcodegen/install.sh', null, { cwd: xcodegenDir })
   await exec.exec('rm -rf', [xcodegenDir])
 }

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ try {
 }
 
 async function installXcodegen() {
+  const currentUser = process.env.USER || os.userInfo().username;
   const xcodegenDir = os.homedir() + '/action-xcodegen/'
   const zipFile = xcodegenDir + 'xcodegen.zip'
   const version = core.getInput('version')
@@ -25,7 +26,7 @@ async function installXcodegen() {
   ])
   await exec.exec('unzip', ['-q', '-o', zipFile], { cwd: xcodegenDir })
   await exec.exec('rm', [zipFile])
-  await exec.exec('sudo', ['chown', 'runner:admin', '/usr/local/share'])
+  await exec.exec('sudo', ['chown', '-R', `${currentUser}:admin`, installPath])
   await exec.exec('xcodegen/install.sh', null, { cwd: xcodegenDir })
   await exec.exec('rm -rf', [xcodegenDir])
 }


### PR DESCRIPTION
I moved from GitHub's hosted macOS runners to Cirrus Runners recently and ran into a failure with the `xcodegen-action`. After digging in a bit, I found it was simple because the default user's username on GitHub runners is `runner`, whereas on a Cirrus macOS runner is was `admin`.

Updated the `index.js` to lookup and current username and use that for the `chown` operation.